### PR TITLE
fix: updated default sonarqube host URL

### DIFF
--- a/sonarscanner-templates/default.properties
+++ b/sonarscanner-templates/default.properties
@@ -7,7 +7,7 @@
 sonar.projectKey=
 
 # The SonarQube server URL.
-sonar.host.url=http://sonarqube:9000
+sonar.host.url=http://localhost:9000
 
 # The authentication token or login of a SonarQube user with
 # Execute Analysis permission on the project.


### PR DESCRIPTION
Fixes the sonarqube dashboard being unaccessible for some users, especially those with a new setup.

#### Purpose
The `default.properties` suggests to use a local sonar host URL of `sonar.host.url=http://sonarqube:9000`, however by default this is not accessible.

When accessing http://sonarqube:9000 I expected my dashboard to load, but obviously this must first be added to your /etc/hosts as an entry, mapped to your localhost.

---
#### Related Issue

https://github.com/luisaveiro/localhost-sonarqube/issues/3

---
#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Refactoring.
- [X] SonarScanner configuration template.
- [ ] Other (documentation).

---
#### Are breaking change introduced?
n/a

---
#### Development Checklist
- [X] My code follows our coding standards.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** accordingly.
- [ ] I have updated the **README**, if necessary.
